### PR TITLE
Persistent Mutes and Bans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/bin
 src/obj
 src/Properties
 src/sodoffmmo.csproj.user
+/muted_banned_users.json

--- a/src/CommandHandlers/ChatMessageHandler.cs
+++ b/src/CommandHandlers/ChatMessageHandler.cs
@@ -11,7 +11,7 @@ class ChatMessageHandler : CommandHandler {
         string message = receivedObject.Get<NetworkObject>("p").Get<string>("chm");
         if (ManagementCommandProcessor.ProcessCommand(message, client))
             return Task.CompletedTask;
-        if (client.Muted()) {
+        if (client.Muted) {
             ClientMuted(client);
             return Task.CompletedTask;
         }

--- a/src/CommandHandlers/ChatMessageHandler.cs
+++ b/src/CommandHandlers/ChatMessageHandler.cs
@@ -11,7 +11,7 @@ class ChatMessageHandler : CommandHandler {
         string message = receivedObject.Get<NetworkObject>("p").Get<string>("chm");
         if (ManagementCommandProcessor.ProcessCommand(message, client))
             return Task.CompletedTask;
-        if (client.TempMuted) {
+        if (client.Muted()) {
             ClientMuted(client);
             return Task.CompletedTask;
         }

--- a/src/CommandHandlers/LoginHandler.cs
+++ b/src/CommandHandlers/LoginHandler.cs
@@ -86,6 +86,11 @@ class LoginHandler : CommandHandler
             if (info.Authenticated) {
                 client.PlayerData.DiplayName = info.DisplayName;
                 client.PlayerData.Role = info.Role;
+                client.PlayerData.VikingId = info.Id;
+                if (info.Id != null) {
+                    client.RealMuted = Client.MutedList.ContainsKey((int)info.Id);
+                    client.Banned = Client.BannedList.ContainsKey((int)info.Id);
+                }
                 return true;
             }
         } catch (Exception ex) {

--- a/src/CommandHandlers/LoginHandler.cs
+++ b/src/CommandHandlers/LoginHandler.cs
@@ -88,8 +88,8 @@ class LoginHandler : CommandHandler
                 client.PlayerData.Role = info.Role;
                 client.PlayerData.VikingId = info.Id;
                 if (info.Id != null) {
-                    client.RealMuted = Client.MutedList.ContainsKey((int)info.Id);
-                    client.Banned = Client.BannedList.ContainsKey((int)info.Id);
+                    client.Muted = PunishmentManager.MutedList.ContainsKey((int)info.Id);
+                    client.Banned = PunishmentManager.BannedList.ContainsKey((int)info.Id);
                 }
                 return true;
             }

--- a/src/Core/Client.cs
+++ b/src/Core/Client.cs
@@ -1,4 +1,5 @@
 ﻿using sodoffmmo.Data;
+using sodoffmmo.Management;
 using System;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
@@ -8,39 +9,15 @@ namespace sodoffmmo.Core;
 public class Client {
     static int id;
     static object lck = new();
-
-                                  // VikingId, Reason (nullable)
-    public static readonly Dictionary<int, string?> MutedList;
-    public static readonly Dictionary<int, string?> BannedList;
-    
-    static Client() { // Runs when Client class is loaded
-        if (File.Exists("muted_banned_users.json")) {
-            try {
-                MutedBannedData? data = JsonSerializer.Deserialize<MutedBannedData>(File.ReadAllText("muted_banned_users.json"));
-                if (data != null) {
-                    MutedList = data.MutedList ?? new();
-                    BannedList = data.BannedList ?? new();
-                    return;
-                }
-            } catch {
-                Console.WriteLine("Data for Muted/Banned users wasn't read. Is it corrupted?");
-            }
-        }
-        MutedList = new();
-        BannedList = new();
-    }
+    protected static List<Client> clients = new();
 
     public int ClientID { get; private set; }
     public PlayerData PlayerData { get; set; } = new();
     public Room? Room { get; private set; }
-    // Used by ban system for smooth unban transitions.
-    public Room? ReturnRoomOnPardon { get; private set; } = null;
     public bool OldApi { get; set; } = false;
 
-    public bool TempMuted { get; set; } = false;
-    public bool RealMuted { get; set; } = false;
+    public bool Muted { get; set; } = false;
     public bool Banned { get; set; } = false;
-    public bool Muted() => TempMuted || RealMuted || Banned;
 
     private readonly Socket socket;
     SocketBuffer socketBuffer = new();
@@ -51,7 +28,14 @@ public class Client {
         socket = clientSocket;
         lock (lck) {
             ClientID = ++id;
+            clients.Add(this);
         }
+    }
+
+    public int TotalClientCount => clients.Count;
+
+    public static Client[] GetAllClients() {
+        return clients.ToArray();
     }
 
     public async Task Receive() {
@@ -75,13 +59,20 @@ public class Client {
     }
 
     public void SetRoom(Room? room) {
+        if (Banned && room != null) {
+            if (Room == PunishmentManager.BanRoom) {
+                PunishmentManager.BanRoom.UpdateClient(this); // This is needed for every time the client changes scene.
+                return;
+            }
+            room = PunishmentManager.BanRoom;
+        }
+
         lock(clientLock) {
             // set variable player data as not valid, but do not reset all player data
             PlayerData.IsValid = false;
 
-            ReturnRoomOnPardon = room; // This is needed so that users are put where they're supposed to when being unbanned.
-            if (Room != null && (!Banned || room?.Name == "LIMBO" || !Room.Name.StartsWith("BannedUserRoom_"))) { // If user is in the ban room they're just fine exactly where they are.
-                Console.WriteLine($"Leave room: {Room.Name} (id={Room.Id}, size={Room.ClientsCount}) IID: {ClientID}");
+            if (Room != null) {
+                if (Room is not BanRoom) Console.WriteLine($"Leave room: {Room.Name} (id={Room.Id}, size={Room.ClientsCount}) IID: {ClientID}");
                 Room.RemoveClient(this);
 
                 NetworkObject data = new();
@@ -90,32 +81,16 @@ public class Client {
                 Room.Send(NetworkObject.WrapObject(0, 1004, data).Serialize());
             }
 
-            if (Banned && room?.Name != "LIMBO") {
-                if (room != null) {
-                    Room = Room.GetOrAdd("BannedUserRoom_" + ClientID, autoRemove: true);
-                    if (Room.Clients.Contains(this)) {
-                        Send(Room.RespondJoinRoom());
-                    } else {
-                        Room.AddClient(this);
-                    }
-                    Send(Room.SubscribeRoom());
-                } else {
-                    Room?.RemoveClient(this);
-                    Room = null;
-                }
-            } else {
-                // set new room (null when SetRoom is used as LeaveRoom)
-                Room = room;
+            // set new room (null when SetRoom is used as LeaveRoom)
+            Room = room;
 
-                if (Room != null) {
-                    Console.WriteLine($"Join room: {Room.Name} RoomID (id={Room.Id}, size={Room.ClientsCount}) IID: {ClientID}");
-                    Room.AddClient(this);
+            if (Room != null) {
+                if (Room is not BanRoom) Console.WriteLine($"Join room: {Room.Name} RoomID (id={Room.Id}, size={Room.ClientsCount}) IID: {ClientID}");
+                Room.AddClient(this);
 
-                    Send(Room.SubscribeRoom());
-                    if (Room.Name != "LIMBO") UpdatePlayerUserVariables(); // do not update user vars if room is limbo
-                }
+                Send(Room.SubscribeRoom());
+                if (Room.Name != "LIMBO") UpdatePlayerUserVariables(); // do not update user vars if room is limbo
             }
-
         }
     }
 
@@ -135,6 +110,9 @@ public class Client {
     }
 
     public void Disconnect() {
+        lock (lck) {
+            clients.Remove(this);
+        }
         try {
             socket.Shutdown(SocketShutdown.Both);
         } finally {
@@ -152,22 +130,14 @@ public class Client {
         scheduledDisconnect = true;
     }
 
+    public void Ban() {
+        Banned = true;
+        SetRoom(PunishmentManager.BanRoom);
+    }
+
     public bool Connected {
         get {
             return socket.Connected && !scheduledDisconnect;
         }
     }
-    public static void SaveMutedBanned() {
-        File.WriteAllText("muted_banned_users.json", JsonSerializer.Serialize(new MutedBannedData {
-            MutedList = MutedList,
-            BannedList = BannedList
-        }, new JsonSerializerOptions {
-             WriteIndented = true
-        }));
-    }
-}
-
-internal sealed class MutedBannedData {
-    public Dictionary<int, string?>? MutedList { get; set; }
-    public Dictionary<int, string?>? BannedList { get; set; }
 }

--- a/src/Core/Room.cs
+++ b/src/Core/Room.cs
@@ -104,8 +104,14 @@ public class Room {
         NetworkObject obj = new();
         NetworkArray roomInfo = new();
         roomInfo.Add(Id);
-        roomInfo.Add(Name); // Room Name
-        roomInfo.Add(Group); // Group Name
+        if (Name.StartsWith("BannedUserRoom_")) {
+            // Send these fake names to the client.
+            roomInfo.Add("YouAreBanned"); // Room Name
+            roomInfo.Add("YouAreBanned"); // Group Name
+        } else {
+            roomInfo.Add(Name); // Room Name
+            roomInfo.Add(Group); // Group Name
+        }
         roomInfo.Add(true); // is game
         roomInfo.Add(false); // is hidden
         roomInfo.Add(false); // is password protected
@@ -136,8 +142,14 @@ public class Room {
 
         NetworkArray r1 = new();
         r1.Add(Id);
-        r1.Add(Name); // Room Name
-        r1.Add(Group); // Group Name
+        if (Name.StartsWith("BannedUserRoom_")) {
+            // Send these fake names to the client.
+            r1.Add("YouAreBanned"); // Room Name
+            r1.Add("YouAreBanned"); // Group Name
+        } else {
+            r1.Add(Name); // Room Name
+            r1.Add(Group); // Group Name
+        }
         r1.Add(true);
         r1.Add(false);
         r1.Add(false);

--- a/src/Core/Room.cs
+++ b/src/Core/Room.cs
@@ -68,7 +68,7 @@ public class Room {
         }
     }
 
-    public void Send(NetworkPacket packet, Client? skip = null) {
+    public virtual void Send(NetworkPacket packet, Client? skip = null) {
         foreach (var roomClient in Clients) {
             if (roomClient != skip) {
                 roomClient.Send(packet);
@@ -100,18 +100,12 @@ public class Room {
         }
     }
 
-    public NetworkPacket RespondJoinRoom() {
+    public virtual NetworkPacket RespondJoinRoom() {
         NetworkObject obj = new();
         NetworkArray roomInfo = new();
         roomInfo.Add(Id);
-        if (Name.StartsWith("BannedUserRoom_")) {
-            // Send these fake names to the client.
-            roomInfo.Add("YouAreBanned"); // Room Name
-            roomInfo.Add("YouAreBanned"); // Group Name
-        } else {
-            roomInfo.Add(Name); // Room Name
-            roomInfo.Add(Group); // Group Name
-        }
+        roomInfo.Add(Name); // Room Name
+        roomInfo.Add(Group); // Group Name
         roomInfo.Add(true); // is game
         roomInfo.Add(false); // is hidden
         roomInfo.Add(false); // is password protected
@@ -136,20 +130,14 @@ public class Room {
         return packet;
     }
 
-    public NetworkPacket SubscribeRoom() {
+    public virtual NetworkPacket SubscribeRoom() {
         NetworkObject obj = new();
         NetworkArray list = new();
 
         NetworkArray r1 = new();
         r1.Add(Id);
-        if (Name.StartsWith("BannedUserRoom_")) {
-            // Send these fake names to the client.
-            r1.Add("YouAreBanned"); // Room Name
-            r1.Add("YouAreBanned"); // Group Name
-        } else {
-            r1.Add(Name); // Room Name
-            r1.Add(Group); // Group Name
-        }
+        r1.Add(Name); // Room Name
+        r1.Add(Group); // Group Name
         r1.Add(true);
         r1.Add(false);
         r1.Add(false);

--- a/src/Data/PlayerData.cs
+++ b/src/Data/PlayerData.cs
@@ -93,17 +93,15 @@ public class PlayerData {
         }
         
         // update the playername (sent with avatardata) if it changes
-        // this is also hit when the player joins the room
+        // this is also sent when the player joins the room
         if (varName == "A" && variables.GetValueOrDefault("A") != value) {
             try {
-                // Gonna surround this in a try/catch in case for some
-                // reason it breaks so that it doesn't break MMO.
                 string? name = JsonSerializer.Deserialize<AvatarData>(value)?.DisplayName;
                 if (name != null && name != DiplayName) {
                     DiplayName = name;
                 }
             }
-            catch (Exception) {} // Pokemon-style exception handling
+            catch (JsonException) {} // Don't break if the data is malformed or something.
         }
 
         // store in directory

--- a/src/Data/PlayerData.cs
+++ b/src/Data/PlayerData.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using sodoffmmo.Core;
 using sodoffmmo.Management;
+using System.Text.Json;
 
 namespace sodoffmmo.Data;
 public class PlayerData {
@@ -37,6 +38,7 @@ public class PlayerData {
 
     public string DiplayName { get; set; } = "placeholder";
     public Role Role { get; set; } = Role.User;
+    public int? VikingId { get; set; }
 
     public long last_ue_time { get; set; } = 0;
 
@@ -88,6 +90,20 @@ public class PlayerData {
         // fix variable value before store
         if (varName == "FP") {
             value = FixMountState(value);
+        }
+        
+        // update the playername (sent with avatardata) if it changes
+        // this is also hit when the player joins the room
+        if (varName == "A" && variables.GetValueOrDefault("A") != value) {
+            try {
+                // Gonna surround this in a try/catch in case for some
+                // reason it breaks so that it doesn't break MMO.
+                string? name = JsonSerializer.Deserialize<AvatarData>(value)?.DisplayName;
+                if (name != null && name != DiplayName) {
+                    DiplayName = name;
+                }
+            }
+            catch (Exception) {} // Pokemon-style exception handling
         }
 
         // store in directory

--- a/src/Management/AuthenticationInfo.cs
+++ b/src/Management/AuthenticationInfo.cs
@@ -12,6 +12,9 @@ public class AuthenticationInfo {
 
     [XmlElement]
     public Role Role { get; set; }
+
+    [XmlElement]
+    public int? Id { get; set; }
 }
 
 [Serializable]

--- a/src/Management/AvatarData.cs
+++ b/src/Management/AvatarData.cs
@@ -1,0 +1,11 @@
+﻿﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace sodoffmmo.Management;
+
+public class AvatarData {
+    public string? DisplayName { get; set; }
+}

--- a/src/Management/BanRoom.cs
+++ b/src/Management/BanRoom.cs
@@ -1,0 +1,63 @@
+﻿using sodoffmmo.Core;
+using sodoffmmo.Data;
+
+namespace sodoffmmo.Management;
+public class BanRoom : Room {
+    public BanRoom(string name) : base(name, name) {}
+
+    public void UpdateClient(Client client) {
+        client.Send(RespondJoinRoom());
+    }
+
+    public override void Send(NetworkPacket packet, Client? skip = null) {
+        // Do nothing.
+    }
+
+    public override NetworkPacket RespondJoinRoom() {
+        NetworkObject obj = new();
+        NetworkArray roomInfo = new();
+        roomInfo.Add(Id);
+        roomInfo.Add(Name); // Room Name
+        roomInfo.Add(Group); // Group Name
+        roomInfo.Add(true); // is game
+        roomInfo.Add(false); // is hidden
+        roomInfo.Add(false); // is password protected
+        roomInfo.Add((short)0); // player count
+        roomInfo.Add((short)1); // max player count
+        roomInfo.Add(new NetworkArray()); // empty roomvars
+        roomInfo.Add((short)0); // spectator count
+        roomInfo.Add((short)0); // max spectator count
+
+        obj.Add("r", roomInfo);
+        obj.Add("ul", new NetworkArray()); // Empty userlist.
+
+        NetworkPacket packet = NetworkObject.WrapObject(0, 4, obj).Serialize();
+        packet.Compress();
+
+        return packet;
+    }
+
+    public override NetworkPacket SubscribeRoom() {
+        NetworkObject obj = new();
+        NetworkArray list = new();
+
+        NetworkArray r1 = new();
+        r1.Add(Id);
+        r1.Add(Name); // Room Name
+        r1.Add(Group); // Group Name
+        r1.Add(true);
+        r1.Add(false);
+        r1.Add(false);
+        r1.Add((short)0); // player count
+        r1.Add((short)1); // max player count
+        r1.Add(new NetworkArray());
+        r1.Add((short)0);
+        r1.Add((short)0);
+
+        list.Add(r1);
+
+        obj.Add("rl", list);
+        obj.Add("g", Group);
+        return NetworkObject.WrapObject(0, 15, obj).Serialize();
+    }
+}

--- a/src/Management/Commands/BanCommand.cs
+++ b/src/Management/Commands/BanCommand.cs
@@ -1,6 +1,5 @@
 ﻿using sodoffmmo.Attributes;
 using sodoffmmo.Core;
-using System.Numerics;
 
 namespace sodoffmmo.Management.Commands;
 
@@ -13,30 +12,24 @@ class BanCommand : IManagementCommand {
         }
         string name = string.Join(' ', arguments);
         Client? target = client.Room.Clients.FirstOrDefault(x => x.PlayerData.DiplayName == name); // Find in this room.
-        if (target == null) { // Find through all the rooms.
-            foreach (Room room in Room.AllRooms()) {
-                if (room == client.Room) continue; // Skip; we already checked here.
-                target = room.Clients.FirstOrDefault(x => x.PlayerData.DiplayName == name);
-                if (target != null) break;
+        if (target == null) { // Search all clients in case the offender left the room.
+            target = Client.GetAllClients().FirstOrDefault(x => x.PlayerData.DiplayName == name);
+            if (target == null) { // If the target is still null, call it a failure.
+                client.Send(Utils.BuildServerSideMessage($"Ban: user {name} not found", "Server"));
+                return;
             }
-        }
-        if (target == null) { // Failure
-            client.Send(Utils.BuildServerSideMessage($"Ban: user {name} not found", "Server"));
-            return;
         }
 
         if (target.Banned) {
             client.Send(Utils.BuildServerSideMessage($"Ban: {name} is already banned", "Server"));
         } else {
-            target.Banned = true;
-            target.SetRoom(target.Room); // This will run the client through the 'if Banned' conditions.
+            target.Ban();
             client.Send(Utils.BuildServerSideMessage($"Ban: {name} has been banned", "Server"));
             if (target.PlayerData.VikingId != null) {
-                Client.BannedList.Add((int)target.PlayerData.VikingId, target.PlayerData.DiplayName);
-                Client.SaveMutedBanned();
+                PunishmentManager.BannedList.Add((int)target.PlayerData.VikingId, target.PlayerData.DiplayName);
+                PunishmentManager.SaveMutedBanned();
             } else {
-                client.Send(Utils.BuildServerSideMessage($"Mute: This user is not authenticated. Their ban will not be permanent!", "Server"));
-
+                client.Send(Utils.BuildServerSideMessage($"Ban: This user is not authenticated. They have been merely kicked instead.", "Server"));
             }
         }
     }
@@ -51,32 +44,22 @@ class UnbanCommand : IManagementCommand {
         }
         string name = string.Join(' ', arguments);
         int? id = null;
-        if (Client.BannedList.ContainsValue(name)) id = Client.BannedList.FirstOrDefault(p => p.Value == name).Key; // Find in list in case they're offline.
-        Client? target = client.Room.Clients.FirstOrDefault(x => x.PlayerData.VikingId == id || x.PlayerData.DiplayName == name); // Find in this room.
-        if (target == null) { // Find through all the rooms.
-            foreach (Room room in Room.AllRooms()) {
-                if (room == client.Room) continue; // Skip; we already checked here.
-                target = room.Clients.FirstOrDefault(x => x.PlayerData.VikingId == id || x.PlayerData.DiplayName == name);
-                if (target != null) break;
-            }
-        }
-        if (target == null && id == null) { // Failure
-            client.Send(Utils.BuildServerSideMessage($"Unban: user {name} not found", "Server"));
+        if (PunishmentManager.BannedList.ContainsValue(name)) // Find in list in case they're offline.
+            id = PunishmentManager.BannedList.FirstOrDefault(p => p.Value == name).Key;
+        
+        if (id == null) { // Failure
+            client.Send(Utils.BuildServerSideMessage($"Unban: User named \"{name}\" is not banned", "Server"));
             return;
         }
 
-        if (target?.Muted() == false || (id != null && !Client.BannedList.ContainsKey((int)id))) {
-            client.Send(Utils.BuildServerSideMessage($"Unban: {name} is not banned", "Server"));
-        } else {
-            if (target != null) {
-                target.Banned = false;
-                target.SetRoom(target.ReturnRoomOnPardon); // Put the target back.
-            }
-            client.Send(Utils.BuildServerSideMessage($"Unban: {name} has been unbanned", "Server"));
-            if (id != null) {
-                Client.BannedList.Remove((int)id);
-                Client.SaveMutedBanned();
-            }
+        Client? target = PunishmentManager.BanRoom.Clients.FirstOrDefault(x => x.PlayerData.VikingId == id || x.PlayerData.DiplayName == name); // Find in ban room.
+        
+        client.Send(Utils.BuildServerSideMessage($"Unban: {name} has been unbanned", "Server"));
+        PunishmentManager.BannedList.Remove((int)id);
+        PunishmentManager.SaveMutedBanned();
+        if (target != null) {
+            target.Banned = false;
+            target.Disconnect(); // Client will handle relogging.
         }
     }
 }

--- a/src/Management/Commands/BanCommand.cs
+++ b/src/Management/Commands/BanCommand.cs
@@ -13,53 +13,21 @@ class BanCommand : IManagementCommand {
         string name = string.Join(' ', arguments);
         Client? target = client.Room.Clients.FirstOrDefault(x => x.PlayerData.DiplayName == name); // Find in this room.
         if (target == null) { // Search all clients in case the offender left the room.
-            target = Client.GetAllClients().FirstOrDefault(x => x.PlayerData.DiplayName == name);
+            target = Server.GetAllClients().FirstOrDefault(x => x.PlayerData.DiplayName == name);
             if (target == null) { // If the target is still null, call it a failure.
                 client.Send(Utils.BuildServerSideMessage($"Ban: user {name} not found", "Server"));
                 return;
             }
         }
 
-        if (target.Banned) {
-            client.Send(Utils.BuildServerSideMessage($"Ban: {name} is already banned", "Server"));
-        } else {
-            target.Ban();
-            client.Send(Utils.BuildServerSideMessage($"Ban: {name} has been banned", "Server"));
-            if (target.PlayerData.VikingId != null) {
-                PunishmentManager.BannedList.Add((int)target.PlayerData.VikingId, target.PlayerData.DiplayName);
-                PunishmentManager.SaveMutedBanned();
+        if (target.Ban()) {
+            if (target?.PlayerData.VikingId == null) {
+                client.Send(Utils.BuildServerSideMessage($"Ban: {name} has been banned", "Server"));
             } else {
-                client.Send(Utils.BuildServerSideMessage($"Ban: This user is not authenticated. They have been merely kicked instead.", "Server"));
+                client.Send(Utils.BuildServerSideMessage($"Ban: {name}'s session has been banned (they are not authenticated)", "Server"));
             }
-        }
-    }
-}
-
-[ManagementCommand("unban", Role.Moderator)]
-class UnbanCommand : IManagementCommand {
-    public void Handle(Client client, string[] arguments) {
-        if (arguments.Length < 1) {
-            client.Send(Utils.BuildServerSideMessage("Unban: Invalid number of arguments", "Server"));
-            return;
-        }
-        string name = string.Join(' ', arguments);
-        int? id = null;
-        if (PunishmentManager.BannedList.ContainsValue(name)) // Find in list in case they're offline.
-            id = PunishmentManager.BannedList.FirstOrDefault(p => p.Value == name).Key;
-        
-        if (id == null) { // Failure
-            client.Send(Utils.BuildServerSideMessage($"Unban: User named \"{name}\" is not banned", "Server"));
-            return;
-        }
-
-        Client? target = PunishmentManager.BanRoom.Clients.FirstOrDefault(x => x.PlayerData.VikingId == id || x.PlayerData.DiplayName == name); // Find in ban room.
-        
-        client.Send(Utils.BuildServerSideMessage($"Unban: {name} has been unbanned", "Server"));
-        PunishmentManager.BannedList.Remove((int)id);
-        PunishmentManager.SaveMutedBanned();
-        if (target != null) {
-            target.Banned = false;
-            target.Disconnect(); // Client will handle relogging.
+        } else {
+            client.Send(Utils.BuildServerSideMessage($"Ban: {name} is already banned", "Server"));
         }
     }
 }

--- a/src/Management/Commands/BanCommand.cs
+++ b/src/Management/Commands/BanCommand.cs
@@ -1,0 +1,82 @@
+﻿using sodoffmmo.Attributes;
+using sodoffmmo.Core;
+using System.Numerics;
+
+namespace sodoffmmo.Management.Commands;
+
+[ManagementCommand("ban", Role.Moderator)]
+class BanCommand : IManagementCommand {
+    public void Handle(Client client, string[] arguments) {
+        if (arguments.Length < 1) {
+            client.Send(Utils.BuildServerSideMessage("Ban: Invalid number of arguments", "Server"));
+            return;
+        }
+        string name = string.Join(' ', arguments);
+        Client? target = client.Room.Clients.FirstOrDefault(x => x.PlayerData.DiplayName == name); // Find in this room.
+        if (target == null) { // Find through all the rooms.
+            foreach (Room room in Room.AllRooms()) {
+                if (room == client.Room) continue; // Skip; we already checked here.
+                target = room.Clients.FirstOrDefault(x => x.PlayerData.DiplayName == name);
+                if (target != null) break;
+            }
+        }
+        if (target == null) { // Failure
+            client.Send(Utils.BuildServerSideMessage($"Ban: user {name} not found", "Server"));
+            return;
+        }
+
+        if (target.Banned) {
+            client.Send(Utils.BuildServerSideMessage($"Ban: {name} is already banned", "Server"));
+        } else {
+            target.Banned = true;
+            target.SetRoom(target.Room); // This will run the client through the 'if Banned' conditions.
+            client.Send(Utils.BuildServerSideMessage($"Ban: {name} has been banned", "Server"));
+            if (target.PlayerData.VikingId != null) {
+                Client.BannedList.Add((int)target.PlayerData.VikingId, target.PlayerData.DiplayName);
+                Client.SaveMutedBanned();
+            } else {
+                client.Send(Utils.BuildServerSideMessage($"Mute: This user is not authenticated. Their ban will not be permanent!", "Server"));
+
+            }
+        }
+    }
+}
+
+[ManagementCommand("unban", Role.Moderator)]
+class UnbanCommand : IManagementCommand {
+    public void Handle(Client client, string[] arguments) {
+        if (arguments.Length < 1) {
+            client.Send(Utils.BuildServerSideMessage("Unban: Invalid number of arguments", "Server"));
+            return;
+        }
+        string name = string.Join(' ', arguments);
+        int? id = null;
+        if (Client.BannedList.ContainsValue(name)) id = Client.BannedList.FirstOrDefault(p => p.Value == name).Key; // Find in list in case they're offline.
+        Client? target = client.Room.Clients.FirstOrDefault(x => x.PlayerData.VikingId == id || x.PlayerData.DiplayName == name); // Find in this room.
+        if (target == null) { // Find through all the rooms.
+            foreach (Room room in Room.AllRooms()) {
+                if (room == client.Room) continue; // Skip; we already checked here.
+                target = room.Clients.FirstOrDefault(x => x.PlayerData.VikingId == id || x.PlayerData.DiplayName == name);
+                if (target != null) break;
+            }
+        }
+        if (target == null && id == null) { // Failure
+            client.Send(Utils.BuildServerSideMessage($"Unban: user {name} not found", "Server"));
+            return;
+        }
+
+        if (target?.Muted() == false || (id != null && !Client.BannedList.ContainsKey((int)id))) {
+            client.Send(Utils.BuildServerSideMessage($"Unban: {name} is not banned", "Server"));
+        } else {
+            if (target != null) {
+                target.Banned = false;
+                target.SetRoom(target.ReturnRoomOnPardon); // Put the target back.
+            }
+            client.Send(Utils.BuildServerSideMessage($"Unban: {name} has been unbanned", "Server"));
+            if (id != null) {
+                Client.BannedList.Remove((int)id);
+                Client.SaveMutedBanned();
+            }
+        }
+    }
+}

--- a/src/Management/Commands/MuteCommand.cs
+++ b/src/Management/Commands/MuteCommand.cs
@@ -1,0 +1,80 @@
+﻿using sodoffmmo.Attributes;
+using sodoffmmo.Core;
+
+namespace sodoffmmo.Management.Commands;
+
+[ManagementCommand("mute", Role.Moderator)]
+class MuteCommand : IManagementCommand {
+    public void Handle(Client client, string[] arguments) {
+        if (arguments.Length < 1) {
+            client.Send(Utils.BuildServerSideMessage("Mute: Invalid number of arguments", "Server"));
+            return;
+        }
+        string name = string.Join(' ', arguments);
+        Client? target = client.Room.Clients.FirstOrDefault(x => x.PlayerData.DiplayName == name); // Find in this room.
+        if (target == null) { // Find through all the rooms.
+            foreach (Room room in Room.AllRooms()) {
+                if (room == client.Room) continue; // Skip; we already checked here.
+                target = room.Clients.FirstOrDefault(x => x.PlayerData.DiplayName == name);
+                if (target != null) break;
+            }
+        }
+        if (target == null) { // Failure
+            client.Send(Utils.BuildServerSideMessage($"Mute: user {name} not found", "Server"));
+            return;
+        }
+
+        if (target.RealMuted) {
+            client.Send(Utils.BuildServerSideMessage($"Mute: {name} is already muted", "Server"));
+        } else {
+            target.RealMuted = true;
+            client.Send(Utils.BuildServerSideMessage($"Mute: {name} has been muted", "Server"));
+            if (target.PlayerData.VikingId != null) {
+                Client.MutedList.Add((int)target.PlayerData.VikingId, target.PlayerData.DiplayName);
+                Client.SaveMutedBanned();
+            } else {
+                client.Send(Utils.BuildServerSideMessage($"Mute: This user is not authenticated. Their mute will not be permanent!", "Server"));
+
+            }
+        }
+    }
+}
+
+[ManagementCommand("unmute", Role.Moderator)]
+class UnmuteCommand : IManagementCommand {
+    public void Handle(Client client, string[] arguments) {
+        if (arguments.Length < 1) {
+            client.Send(Utils.BuildServerSideMessage("Unmute: Invalid number of arguments", "Server"));
+            return;
+        }
+        string name = string.Join(' ', arguments);
+        int? id = null;
+        if (Client.MutedList.ContainsValue(name)) id = Client.MutedList.FirstOrDefault(p => p.Value == name).Key; // Find in list in case they're offline.
+        Client? target = client.Room.Clients.FirstOrDefault(x => x.PlayerData.VikingId == id || x.PlayerData.DiplayName == name); // Find in this room.
+        if (target == null) { // Find through all the rooms.
+            foreach (Room room in Room.AllRooms()) {
+                if (room == client.Room) continue; // Skip; we already checked here.
+                target = room.Clients.FirstOrDefault(x => x.PlayerData.VikingId == id || x.PlayerData.DiplayName == name);
+                if (target != null) break;
+            }
+        }
+        if (target == null && id == null) { // Failure
+            client.Send(Utils.BuildServerSideMessage($"Unmute: user {name} not found", "Server"));
+            return;
+        }
+
+        if (target?.Muted() == false || (id != null && !Client.MutedList.ContainsKey((int)id))) {
+            client.Send(Utils.BuildServerSideMessage($"Unmute: {name} is not muted", "Server"));
+        } else {
+            if (target != null) {
+                target.RealMuted = false;
+                target.TempMuted = false; // Undo this too I guess.
+            }
+            client.Send(Utils.BuildServerSideMessage($"Unmute: {name} has been unmuted", "Server"));
+            if (id != null) {
+                Client.MutedList.Remove((int)id);
+                Client.SaveMutedBanned();
+            }
+        }
+    }
+}

--- a/src/Management/Commands/MuteCommand.cs
+++ b/src/Management/Commands/MuteCommand.cs
@@ -13,60 +13,18 @@ class MuteCommand : IManagementCommand {
         string name = string.Join(' ', arguments);
         Client? target = client.Room.Clients.FirstOrDefault(x => x.PlayerData.DiplayName == name); // Find in this room.
         if (target == null) { // Search all clients in case the offender left the room.
-            target = Client.GetAllClients().FirstOrDefault(x => x.PlayerData.DiplayName == name);
+            target = Server.GetAllClients().FirstOrDefault(x => x.PlayerData.DiplayName == name);
             if (target == null) { // Failure
                 client.Send(Utils.BuildServerSideMessage($"Mute: user {name} not found", "Server"));
                 return;
             }
         }
 
-        if (target.PlayerData.VikingId != null) {
-            if (PunishmentManager.MutedList.ContainsKey((int)target.PlayerData.VikingId)) {
-                client.Send(Utils.BuildServerSideMessage($"Mute: {name} is already muted", "Server"));
-            } else {
-                target.Muted = true;
-                client.Send(Utils.BuildServerSideMessage($"Mute: {name} has been muted", "Server"));
-                PunishmentManager.MutedList.Add((int)target.PlayerData.VikingId, target.PlayerData.DiplayName);
-                PunishmentManager.SaveMutedBanned();
-            }
-        } else {
-            target.Muted = true;
+        if (target.Mute()) {
             client.Send(Utils.BuildServerSideMessage($"Mute: {name} has been muted", "Server"));
-            client.Send(Utils.BuildServerSideMessage($"Mute: This user is not authenticated. Their mute will not be permanent!", "Server"));
-        }
-    }
-}
-
-[ManagementCommand("unmute", Role.Moderator)]
-class UnmuteCommand : IManagementCommand {
-    public void Handle(Client client, string[] arguments) {
-        if (arguments.Length < 1) {
-            client.Send(Utils.BuildServerSideMessage("Unmute: Invalid number of arguments", "Server"));
-            return;
-        }
-        string name = string.Join(' ', arguments);
-        int? id = null;
-        if (PunishmentManager.MutedList.ContainsValue(name)) id = PunishmentManager.MutedList.FirstOrDefault(p => p.Value == name).Key; // Find in list in case they're offline.
-        Client? target = client.Room.Clients.FirstOrDefault(x => x.PlayerData.VikingId == id || x.PlayerData.DiplayName == name); // Find in this room.
-        if (target == null) { // Search all clients in case the target left the room.
-            target = Client.GetAllClients().FirstOrDefault(x => x.PlayerData.DiplayName == name);
-            if (target == null && id == null) { // Failure
-                client.Send(Utils.BuildServerSideMessage($"Unmute: user {name} not found", "Server"));
-                return;
-            }
-        }
-
-        if (target?.Muted == false || (id != null && !PunishmentManager.MutedList.ContainsKey((int)id))) {
-            client.Send(Utils.BuildServerSideMessage($"Unmute: {name} is not muted", "Server"));
         } else {
-            if (target != null) {
-                target.Muted = false;
-            }
-            client.Send(Utils.BuildServerSideMessage($"Unmute: {name} has been unmuted", "Server"));
-            if (id != null) {
-                PunishmentManager.MutedList.Remove((int)id);
-                PunishmentManager.SaveMutedBanned();
-            }
+            client.Send(Utils.BuildServerSideMessage($"Mute: {name} is already muted", "Server"));
         }
+        if (target?.PlayerData.VikingId == null) client.Send(Utils.BuildServerSideMessage($"Mute: Their mute will not be persistent since they are not authenticated", "Server"));
     }
 }

--- a/src/Management/Commands/TempMuteCommand.cs
+++ b/src/Management/Commands/TempMuteCommand.cs
@@ -6,19 +6,25 @@ namespace sodoffmmo.Management.Commands;
 [ManagementCommand("tempmute", Role.Moderator)]
 class TempMuteCommand : IManagementCommand {
     public void Handle(Client client, string[] arguments) {
-        if (arguments.Length != 1) {
+        if (arguments.Length < 1) {
             client.Send(Utils.BuildServerSideMessage("TempMute: Invalid number of arguments", "Server"));
             return;
         }
-        Client? target = client.Room.Clients.FirstOrDefault(x => x.PlayerData.DiplayName == arguments[0]);
+        string name = string.Join(' ', arguments);
+        Client? target = client.Room.Clients.FirstOrDefault(x => x.PlayerData.DiplayName == name);
         if (target == null) {
-            client.Send(Utils.BuildServerSideMessage($"TempMute: user {arguments[0]} not found", "Server"));
+            client.Send(Utils.BuildServerSideMessage($"TempMute: user {name} not found", "Server"));
             return;
         }
-        target.TempMuted = !target.TempMuted;
-        if (target.TempMuted)
-            client.Send(Utils.BuildServerSideMessage($"TempMute: {arguments[0]} has been temporarily muted", "Server"));
-        else
-            client.Send(Utils.BuildServerSideMessage($"TempMute: {arguments[0]} has been unmuted", "Server"));
+
+        if (target.RealMuted) {
+            client.Send(Utils.BuildServerSideMessage($"TempMute: {name} is already regular muted", "Server"));
+        } else {
+            target.TempMuted = !target.TempMuted;
+            if (target.TempMuted)
+                client.Send(Utils.BuildServerSideMessage($"TempMute: {name} has been temporarily muted", "Server"));
+            else
+                client.Send(Utils.BuildServerSideMessage($"TempMute: {name} has been unmuted", "Server"));
+        }
     }
 }

--- a/src/Management/Commands/TempMuteCommand.cs
+++ b/src/Management/Commands/TempMuteCommand.cs
@@ -17,14 +17,11 @@ class TempMuteCommand : IManagementCommand {
             return;
         }
 
-        if (target.RealMuted) {
-            client.Send(Utils.BuildServerSideMessage($"TempMute: {name} is already regular muted", "Server"));
+        if (target.Muted) {
+            client.Send(Utils.BuildServerSideMessage($"TempMute: {name} is already muted", "Server"));
         } else {
-            target.TempMuted = !target.TempMuted;
-            if (target.TempMuted)
-                client.Send(Utils.BuildServerSideMessage($"TempMute: {name} has been temporarily muted", "Server"));
-            else
-                client.Send(Utils.BuildServerSideMessage($"TempMute: {name} has been unmuted", "Server"));
+            target.Muted = true;
+            client.Send(Utils.BuildServerSideMessage($"TempMute: {name} has been temporarily muted", "Server"));
         }
     }
 }

--- a/src/Management/Commands/UnbanCommand.cs
+++ b/src/Management/Commands/UnbanCommand.cs
@@ -1,0 +1,31 @@
+﻿using sodoffmmo.Attributes;
+using sodoffmmo.Core;
+
+namespace sodoffmmo.Management.Commands;
+
+[ManagementCommand("unban", Role.Moderator)]
+class UnbanCommand : IManagementCommand {
+    public void Handle(Client client, string[] arguments) {
+        if (arguments.Length < 1) {
+            client.Send(Utils.BuildServerSideMessage("Unban: Invalid number of arguments", "Server"));
+            return;
+        }
+        string name = string.Join(' ', arguments);
+        int? id = null;
+        if (PunishmentManager.BannedList.ContainsValue(name)) // Find in list in case they're offline.
+            id = PunishmentManager.BannedList.FirstOrDefault(p => p.Value == name).Key;
+        
+        if (id == null) { // Failure
+            client.Send(Utils.BuildServerSideMessage($"Unban: User named \"{name}\" is not banned", "Server"));
+            return;
+        }
+
+        Client? target = PunishmentManager.BanRoom.Clients.FirstOrDefault(x => x.PlayerData.VikingId == id || x.PlayerData.DiplayName == name); // Find in ban room.
+
+        if (target.Unban(id)) {
+            client.Send(Utils.BuildServerSideMessage($"Unban: {name} has been unbanned", "Server"));
+        } else {
+            client.Send(Utils.BuildServerSideMessage($"Unban: {name} is not banned", "Server"));
+        }
+    }
+}

--- a/src/Management/Commands/UnmuteCommand.cs
+++ b/src/Management/Commands/UnmuteCommand.cs
@@ -1,0 +1,31 @@
+﻿using sodoffmmo.Attributes;
+using sodoffmmo.Core;
+
+namespace sodoffmmo.Management.Commands;
+
+[ManagementCommand("unmute", Role.Moderator)]
+class UnmuteCommand : IManagementCommand {
+    public void Handle(Client client, string[] arguments) {
+        if (arguments.Length < 1) {
+            client.Send(Utils.BuildServerSideMessage("Unmute: Invalid number of arguments", "Server"));
+            return;
+        }
+        string name = string.Join(' ', arguments);
+        int? id = null;
+        if (PunishmentManager.MutedList.ContainsValue(name)) id = PunishmentManager.MutedList.FirstOrDefault(p => p.Value == name).Key; // Find in list in case they're offline.
+        Client? target = client.Room.Clients.FirstOrDefault(x => x.PlayerData.VikingId == id || x.PlayerData.DiplayName == name); // Find in this room.
+        if (target == null) { // Search all clients in case the target left the room.
+            target = Server.GetAllClients().FirstOrDefault(x => x.PlayerData.DiplayName == name);
+            if (target == null && id == null) { // Failure
+                client.Send(Utils.BuildServerSideMessage($"Unmute: user {name} not found", "Server"));
+                return;
+            }
+        }
+
+        if (target.Unmute(id)) {
+            client.Send(Utils.BuildServerSideMessage($"Unmute: {name} has been unmuted", "Server"));
+        } else {
+            client.Send(Utils.BuildServerSideMessage($"Unmute: {name} is not muted", "Server"));
+        }
+    }
+}

--- a/src/Management/PunishmentManager.cs
+++ b/src/Management/PunishmentManager.cs
@@ -1,10 +1,9 @@
 ﻿using sodoffmmo.Core;
-using sodoffmmo.Data;
 using System.Text.Json;
 
 namespace sodoffmmo.Management;
 
-public class PunishmentManager {
+public static class PunishmentManager {
     // VikingId, Reason (nullable)
     public static readonly Dictionary<int, string?> MutedList;
     public static readonly Dictionary<int, string?> BannedList;
@@ -35,69 +34,97 @@ public class PunishmentManager {
              WriteIndented = true
         }));
     }
+
+    /// <summary>
+    /// Mute a user.
+    /// </summary>
+    /// <param name="target">User to mute - can be null, but id should be set in that case.</param>
+    /// <param name="id">Optional vikingid of the user to mute.</param>
+    /// <returns>False if already muted, otherwise true.</returns>
+    public static bool Mute(this Client? target, int? id = null) {
+        if (target != null) {
+            id ??= target.PlayerData.VikingId;
+            if (target.Muted && id == null) return false;
+            target.Muted = true;
+        }
+
+        if (id != null) {
+            if (MutedList.ContainsKey((int)id)) return false;
+            MutedList.Add((int)id, target?.PlayerData.DiplayName);
+            SaveMutedBanned();
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Unmute a user.
+    /// </summary>
+    /// <param name="target">User to unmute - can be null, but id should be set in that case.</param>
+    /// <param name="id">Optional vikingid of the user to unmute.</param>
+    /// <returns>False if the user isn't muted, otherwise true.</returns>
+    public static bool Unmute(this Client? target, int? id=null) {
+        if (target != null) {
+            if (!target.Muted) return false;
+            target.Muted = false;
+            id ??= target.PlayerData.VikingId;
+        }
+
+        if (id != null) {
+            if (!MutedList.Remove((int)id)) return false;
+            SaveMutedBanned();
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Ban a user.
+    /// </summary>
+    /// <param name="target">User to ban - can be null, but id should be set in that case.</param>
+    /// <param name="id">Optional vikingid of the user to ban.</param>
+    /// <returns>False if already banned, otherwise true.</returns>
+    public static bool Ban(this Client? target, int? id=null) {
+        if (target != null) {
+            if (target.Banned) return false;
+            target.Banned = true;
+            target.SetRoom(BanRoom);
+            id ??= target.PlayerData.VikingId;
+        }
+
+        if (id != null) {
+            if (BannedList.ContainsKey((int)id)) return false;
+            BannedList.Add((int)id, target?.PlayerData.DiplayName);
+            SaveMutedBanned();
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Unban a user.
+    /// </summary>
+    /// <param name="target">User to unban - can be null, but id should be set in that case.</param>
+    /// <param name="id">Optional vikingid of the user to unban.</param>
+    /// <returns>False if the user isn't banned, otherwise true.</returns>
+    public static bool Unban(this Client? target, int? id=null) {
+        if (target != null) {
+            if (!target.Banned) return false;
+            target.Banned = false;
+            target.Disconnect(); // Client will handle relogging.
+            id ??= target.PlayerData.VikingId;
+        }
+
+        if (id != null) {
+            if (!BannedList.Remove((int)id)) return false;
+            SaveMutedBanned();
+        }
+
+        return true;
+    }
 }
 
 internal sealed class MutedBannedData {
     public Dictionary<int, string?>? MutedList { get; set; }
     public Dictionary<int, string?>? BannedList { get; set; }
-}
-
-public class BanRoom : Room {
-    public BanRoom(string name) : base(name, name) {}
-
-    public void UpdateClient(Client client) {
-        client.Send(RespondJoinRoom());
-    }
-
-    public override void Send(NetworkPacket packet, Client? skip = null) {
-        // Do nothing.
-    }
-
-    public override NetworkPacket RespondJoinRoom() {
-        NetworkObject obj = new();
-        NetworkArray roomInfo = new();
-        roomInfo.Add(Id);
-        roomInfo.Add(Name); // Room Name
-        roomInfo.Add(Group); // Group Name
-        roomInfo.Add(true); // is game
-        roomInfo.Add(false); // is hidden
-        roomInfo.Add(false); // is password protected
-        roomInfo.Add((short)0); // player count
-        roomInfo.Add((short)1); // max player count
-        roomInfo.Add(new NetworkArray()); // empty roomvars
-        roomInfo.Add((short)0); // spectator count
-        roomInfo.Add((short)0); // max spectator count
-
-        obj.Add("r", roomInfo);
-        obj.Add("ul", new NetworkArray()); // Empty userlist.
-
-        NetworkPacket packet = NetworkObject.WrapObject(0, 4, obj).Serialize();
-        packet.Compress();
-
-        return packet;
-    }
-
-    public override NetworkPacket SubscribeRoom() {
-        NetworkObject obj = new();
-        NetworkArray list = new();
-
-        NetworkArray r1 = new();
-        r1.Add(Id);
-        r1.Add(Name); // Room Name
-        r1.Add(Group); // Group Name
-        r1.Add(true);
-        r1.Add(false);
-        r1.Add(false);
-        r1.Add((short)0); // player count
-        r1.Add((short)1); // max player count
-        r1.Add(new NetworkArray());
-        r1.Add((short)0);
-        r1.Add((short)0);
-
-        list.Add(r1);
-
-        obj.Add("rl", list);
-        obj.Add("g", Group);
-        return NetworkObject.WrapObject(0, 15, obj).Serialize();
-    }
 }

--- a/src/Management/PunishmentManager.cs
+++ b/src/Management/PunishmentManager.cs
@@ -1,0 +1,103 @@
+﻿using sodoffmmo.Core;
+using sodoffmmo.Data;
+using System.Text.Json;
+
+namespace sodoffmmo.Management;
+
+public class PunishmentManager {
+    // VikingId, Reason (nullable)
+    public static readonly Dictionary<int, string?> MutedList;
+    public static readonly Dictionary<int, string?> BannedList;
+
+    public static readonly BanRoom BanRoom = new("YouAreBanned");
+
+    static PunishmentManager() { // Runs when Client class is loaded
+        if (File.Exists("muted_banned_users.json")) {
+            try {
+                MutedBannedData? data = JsonSerializer.Deserialize<MutedBannedData>(File.ReadAllText("muted_banned_users.json"));
+                if (data != null) {
+                    MutedList = data.MutedList ?? new();
+                    BannedList = data.BannedList ?? new();
+                    return;
+                }
+            } catch {
+                Console.WriteLine("Data for Muted/Banned users wasn't read. It might be corrupted or malformed.");
+            }
+        }
+        MutedList = new();
+        BannedList = new();
+    }
+    public static void SaveMutedBanned() {
+        File.WriteAllText("muted_banned_users.json", JsonSerializer.Serialize(new MutedBannedData {
+            MutedList = MutedList,
+            BannedList = BannedList
+        }, new JsonSerializerOptions {
+             WriteIndented = true
+        }));
+    }
+}
+
+internal sealed class MutedBannedData {
+    public Dictionary<int, string?>? MutedList { get; set; }
+    public Dictionary<int, string?>? BannedList { get; set; }
+}
+
+public class BanRoom : Room {
+    public BanRoom(string name) : base(name, name) {}
+
+    public void UpdateClient(Client client) {
+        client.Send(RespondJoinRoom());
+    }
+
+    public override void Send(NetworkPacket packet, Client? skip = null) {
+        // Do nothing.
+    }
+
+    public override NetworkPacket RespondJoinRoom() {
+        NetworkObject obj = new();
+        NetworkArray roomInfo = new();
+        roomInfo.Add(Id);
+        roomInfo.Add(Name); // Room Name
+        roomInfo.Add(Group); // Group Name
+        roomInfo.Add(true); // is game
+        roomInfo.Add(false); // is hidden
+        roomInfo.Add(false); // is password protected
+        roomInfo.Add((short)0); // player count
+        roomInfo.Add((short)1); // max player count
+        roomInfo.Add(new NetworkArray()); // empty roomvars
+        roomInfo.Add((short)0); // spectator count
+        roomInfo.Add((short)0); // max spectator count
+
+        obj.Add("r", roomInfo);
+        obj.Add("ul", new NetworkArray()); // Empty userlist.
+
+        NetworkPacket packet = NetworkObject.WrapObject(0, 4, obj).Serialize();
+        packet.Compress();
+
+        return packet;
+    }
+
+    public override NetworkPacket SubscribeRoom() {
+        NetworkObject obj = new();
+        NetworkArray list = new();
+
+        NetworkArray r1 = new();
+        r1.Add(Id);
+        r1.Add(Name); // Room Name
+        r1.Add(Group); // Group Name
+        r1.Add(true);
+        r1.Add(false);
+        r1.Add(false);
+        r1.Add((short)0); // player count
+        r1.Add((short)1); // max player count
+        r1.Add(new NetworkArray());
+        r1.Add((short)0);
+        r1.Add((short)0);
+
+        list.Add(r1);
+
+        obj.Add("rl", list);
+        obj.Add("g", Group);
+        return NetworkObject.WrapObject(0, 15, obj).Serialize();
+    }
+}


### PR DESCRIPTION
_You're probably tired of me; this is my second PR in the past month._
Spirtix told me to put implementation for mutes and bans into a separate PR so I did.


This PR adds the functionality for mutes and bans alone. However, they only really work if the user being muted or banned is authenticated.
Additions:
* A file is created containing the IDs and names of muted and banned players.
* Players can be banned/muted even if they are in another room.
* Players can be unbanned/unmuted even if they are in another room or offline.
* Banned players are placed in a special room with only them in it. They will remain in this room until they leave, even when they're supposed to transition to other rooms. The exception is LIMBO, which they will still join as normal (but that shouldn't cause any problems).
Changes:
* The `tempmute` command has been changed to allow spaces in the playername (in JumpStart and Math Blaster, this is unavoidable without modding due to the nature of generated names). This change is also reflected in the new `mute`, `ban`, `unmute`, and `unban` commands.
* The DiplayName<sup>[_(sic)_](https://en.wikipedia.org/wiki/Sic)</sup> is now updated based on AvatarData when the player updates their name (possible to do in vanilla JumpStart/Blaster).

In order for this to be effective, SoDOff-Project/sodoff#25 will also have to be merged.