### PR TITLE
Ambassador Configuration Revamp

### DIFF
--- a/src/CommandHandlers/CounterHandler.cs
+++ b/src/CommandHandlers/CounterHandler.cs
@@ -7,15 +7,23 @@ namespace sodoffmmo.CommandHandlers;
 [ExtensionCommandHandler("SCE")]
 class CounterEventHandler : CommandHandler {
     public override Task Handle(Client client, NetworkObject receivedObject) { // {"a":13,"c":1,"p":{"c":"SCE","p":{"NAME":"COUNT"},"r":-1}}
-        if (client.Room is SpecialRoom room) {
+        if (client.Room is SpecialRoom room && room.ambassadorConfig != null) {
             string name = receivedObject.Get<NetworkObject>("p").Get<string>("NAME");
-            if (name == "COUNT" || name == "COUNT2" || name == "COUNT3") {
-                int index = name switch {
-                    "COUNT"  => 0,
-                    "COUNT2" => 1,
-                    "COUNT3" => 2
-                };
-                room.ambassadorGauges[index] = Math.Min(100, room.ambassadorGauges[index]+(1/Configuration.ServerConfiguration.AmbassadorGaugePlayers));
+            int index = name switch {
+                "COUNT"  => 0,
+                "COUNT2" => 1,
+                "COUNT3" => 2,
+                _ => -1
+            };
+            if (index != -1) {
+                double newVal = room.ambassadorGauges[index] + (1/room.ambassadorConfig.GaugePlayers);
+                if (newVal > room.ambassadorConfig.GaugeMax) {
+                    room.ambassadorGauges[index] = room.ambassadorConfig.ResetOnMaxReached
+                        ? room.ambassadorConfig.GaugeStart
+                        : room.ambassadorConfig.GaugeMax;
+                } else {
+                    room.ambassadorGauges[index] = newVal;
+                }
                 room.Send(Utils.VlNetworkPacket(room.GetRoomVars(), client.Room.Id));
             } else {
                 Console.WriteLine($"Invalid attempt to increment room var {name} in {room.Name}.");

--- a/src/Core/Configuration.cs
+++ b/src/Core/Configuration.cs
@@ -33,11 +33,7 @@ internal sealed class ServerConfiguration {
     public int EventTimer { get; set; } = 30;
     public int FirstEventTimer { get; set; } = 10;
     public Dictionary<string, string[][]> RoomAlerts { get; set; } = new();
-    public string[] AmbassadorRooms { get; set; } = Array.Empty<string>();
-    public int AmbassadorGaugeStart { get; set; } = 75;
-    public float AmbassadorGaugeDecayRate { get; set; } = 60;
-    public bool AmbassadorGaugeDecayOnlyWhenInRoom { get; set; } = true;
-    public float AmbassadorGaugePlayers { get; set; } = 0.5f;
+    public Dictionary<string, AmbassadorConfiguration> AmbassadorRooms { get; set; } = new();
     public int RacingMaxPlayers { get; set; } = 6;
     public int RacingMinPlayers { get; set; } = 2;
     public int RacingMainLobbyTimer { get; set; } = 15;
@@ -52,4 +48,13 @@ internal sealed class ServerConfiguration {
 
 public enum AuthenticationMode {
     Disabled, Optional, RequiredForChat, Required
+}
+
+public class AmbassadorConfiguration {
+    public int GaugeStart { get; set; } = 75;
+    public int GaugeMax { get; set; } = 100;
+    public float GaugeDecayRate { get; set; } = 60;
+    public bool GaugeDecayOnlyWhenInRoom { get; set; } = true;
+    public float GaugePlayers { get; set; } = 0.5f;
+    public bool ResetOnMaxReached { get; set; } = false;
 }

--- a/src/Core/SpecialRoom.cs
+++ b/src/Core/SpecialRoom.cs
@@ -3,6 +3,7 @@ using sodoffmmo.Data;
 namespace sodoffmmo.Core;
 
 public class SpecialRoom : Room {
+    public AmbassadorConfiguration? ambassadorConfig;
     public double[] ambassadorGauges = new double[3]; // There is always a maximum of 3.
     System.Timers.Timer? ambassadorTimer;
 
@@ -20,26 +21,34 @@ public class SpecialRoom : Room {
             }
         }
 
-        foreach (var room in Configuration.ServerConfiguration.AmbassadorRooms) {
+        foreach (var datapair in Configuration.ServerConfiguration.AmbassadorRooms) {
+            string room = datapair.Key;
             Console.WriteLine($"Setup Ambassador for {room}");
-            (rooms.GetValueOrDefault(room) as SpecialRoom ?? new SpecialRoom(room)).InitAmbassador();
+            (rooms.GetValueOrDefault(room) as SpecialRoom ?? new SpecialRoom(room)).InitAmbassador(datapair.Value);
         }
     }
 
     public SpecialRoom(string name) : base(name) {}
 
-    public void InitAmbassador() {
-        for (int i=0;i<3;i++) ambassadorGauges[i] = Configuration.ServerConfiguration.AmbassadorGaugeStart;
-        ambassadorTimer = new(Configuration.ServerConfiguration.AmbassadorGaugeDecayRate * 1000) {
-            AutoReset = true,
-            Enabled = true
-        };
-        ambassadorTimer.Elapsed += (sender, e) => {
-            if (!Configuration.ServerConfiguration.AmbassadorGaugeDecayOnlyWhenInRoom || ClientsCount > 0) {
-                for (int i=0;i<3;i++) ambassadorGauges[i] = Math.Max(0, ambassadorGauges[i]-1);
-                Send(Utils.VlNetworkPacket(GetRoomVars(), Id));
-            }
-        };
+    public void InitAmbassador(AmbassadorConfiguration config) {
+        this.ambassadorConfig = config;
+        for (int i=0;i<this.ambassadorGauges.Length;i++) this.ambassadorGauges[i] = config.GaugeStart;
+        if (config.GaugeDecayRate > 0) {
+            this.ambassadorTimer = new(config.GaugeDecayRate * 1000) {
+                AutoReset = true,
+                Enabled = true
+            };
+            this.ambassadorTimer.Elapsed += (sender, e) => {
+                if (!config.GaugeDecayOnlyWhenInRoom || ClientsCount > 0) {
+                    for (int i=0;i<this.ambassadorGauges.Length;i++) {
+                        if (this.ambassadorGauges[i] > 0) {
+                            this.ambassadorGauges[i]--;
+                            Send(Utils.VlNetworkPacket(GetRoomVars(), Id));
+                        }
+                    }
+                }
+            };
+        }
     }
 
     internal override NetworkArray GetRoomVars() {

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -33,20 +33,32 @@
       "JunkYardEMD": [ ["1", 20.0, 240, 300, 60, 0] ],
     },
 
-    "// AmbassadorRooms": "Rooms with ambassadors (MB funzones).",
-    "AmbassadorRooms": ["Spaceport"],
-
-    "// AmbassadorGaugeStart": "The starting value for all ambassador gauges (MB funzones).",
-    "AmbassadorGaugeStart": 75,
-
-    "// AmbassadorGaugeDecayRate": "Time in seconds before ambassador gauges decrease (MB funzones).",
-    "AmbassadorGaugeDecayRate": 60,
-
-    "// AmbassadorGaugeDecayOnlyWhenInRoom": "Only decrease ambassador gauges when there is at least one player in the room (MB funzones).",
-    "AmbassadorGaugeDecayOnlyWhenInRoom": true,
-
-    "// AmbassadorGaugePlayers": "Denominator for filling the ambassador gauges (MB funzones).",
-    "AmbassadorGaugePlayers": 0.5,
+    "// AmbassadorRooms": {"": "Rooms with ambassadors.",
+      "// GaugeStart": "The starting value for ambassador gauges.",
+      "// GaugeMax": "Maximum value for ambassador gauges.",
+      "// GaugeDecayRate": "Time in seconds before ambassador gauges decrease. Use 0 to disable.",
+      "// GaugeDecayOnlyWhenInRoom": "Only decrease ambassador gauges when there is at least one player in the room.",
+      "// GaugePlayers": "Denominator for adding to ambassador gauges. ( 1 / GaugePlayers )",
+      "// ResetOnMaxReached": "Whether to reset the gauge to GaugeStart after it reaches GaugeMax."
+    },
+    "AmbassadorRooms": {
+      "Spaceport": {
+        "GaugeStart": 75,
+        "GaugeMax": 100,
+        "GaugeDecayRate": 60,
+        "GaugeDecayOnlyWhenInRoom": true,
+        "GaugePlayers": 0.5,
+        "ResetOnMaxReached": false
+      },
+      "DownTown": {
+        "GaugeStart": 0,
+        "GaugeMax": 3600,
+        "GaugeDecayRate": 0,
+        "GaugeDecayOnlyWhenInRoom": false,
+        "GaugePlayers": 1,
+        "ResetOnMaxReached": true
+      }
+    },
 
     "// RacingMaxPlayers": "maximum players allowed in Thunder Run Racing (no more than 6)",
     "RacingMaxPlayers": 6,


### PR DESCRIPTION
Changed ambassador configuration to add support for World of JumpStart funzones using the SnowmanBuilder script.
Also allow ambassador settings to be set per-ambassador instead of for all ambassadors.